### PR TITLE
History delete

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Andrés Martínez García, Antonio Martínez Rojas
+Copyright (c) 2021 Andrés Martínez García, Antonio Martínez Rojas
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "start": "node -r dotenv/config source/boot.js dotenv_config_path=env/devel.env",
         "start:prod": "node -r dotenv/config source/boot.js dotenv_config_path=env/prod.env",
-        "test": "jest ./test --silent",
+        "test": "jest ./test -i --silent",
         "coverage": "npm test -- --coverage"
     },
     "author": "amg98@github.com, a8081@github.com",

--- a/source/routes/HistoryController.js
+++ b/source/routes/HistoryController.js
@@ -34,6 +34,22 @@ class HistoryController {
         });
     };
 
+    /**
+     * Delete the purchase history for the logged user
+     * @route DELETE /history
+     * @group history - Purchases history per user
+     * @param {string}  userToken.query.required         - User JWT token
+     * @returns {}                      204 - Returns nothing
+     * @returns {ValidationError}       400 - Supplied parameters are invalid
+     * @returns {UserAuthError}         401 - User is not authorized to perform this operation
+     * @returns {DatabaseError}         500 - Database error
+     */
+    deleteMethod(req, res) {
+        HistoryEntry.find({ userID: req.query.userID }).remove()
+            .then(() => res.status(204))
+            .catch(() => res.status(500).json({ reason: "Database error" }));
+    }
+
     createEntry(entry) {
         const historyEntry = new HistoryEntry(entry);
         return historyEntry.save();
@@ -45,10 +61,12 @@ class HistoryController {
     }
 
     constructor(apiPrefix, router) {
+        const apiUrl = apiPrefix + "/history";
         const userTokenValidators = [Validators.Required("userToken"), AuthorizeJWT];
         const beforeTimestampValidators = [Validators.Required("beforeTimestamp"), Validators.ToDate("beforeTimestamp")];
         const pageSizeValidators = [Validators.Required("pageSize"), Validators.Range("pageSize", 1, 20)];
-        router.get(apiPrefix + "/history", ...userTokenValidators, ...beforeTimestampValidators, ...pageSizeValidators, this.getMethod.bind(this));
+        router.get(apiUrl, ...userTokenValidators, ...beforeTimestampValidators, ...pageSizeValidators, this.getMethod.bind(this));
+        router.delete(apiUrl, ...userTokenValidators, this.deleteMethod.bind(this));
     }
 }
 

--- a/source/routes/HistoryController.js
+++ b/source/routes/HistoryController.js
@@ -45,8 +45,8 @@ class HistoryController {
      * @returns {DatabaseError}         500 - Database error
      */
     deleteMethod(req, res) {
-        HistoryEntry.find({ userID: req.query.userID }).remove()
-            .then(() => res.status(204))
+        HistoryEntry.deleteMany({ userID: req.query.userID })
+            .then(() => res.sendStatus(204))
             .catch(() => res.status(500).json({ reason: "Database error" }));
     }
 

--- a/test/e2e/HistoryControllerAPI.spec.js
+++ b/test/e2e/HistoryControllerAPI.spec.js
@@ -9,19 +9,33 @@ describe("HistoryController API", () => {
     const testURL = "/api/v1/history";
     const db = new DatabaseConnection();
     let userToken, userID;
+    let testEntry;
 
     beforeAll(async () => {
         const user = await utils.authTestUser();
         userToken = user.userToken;
         userID = user.userID;
         await db.setup();
+
+        testEntry = {
+            userID,
+            timestamp: new Date().toISOString(),
+            operationType: "payment",
+            products: [
+                {
+                    _id: mongoose.Types.ObjectId(1).toHexString(),
+                    quantity: 12,
+                    unitPriceEuros: 4
+                }
+            ]
+        };
     });
 
     afterAll(() => db.close());
 
     beforeEach(done => mongoose.connection.dropCollection("historyentries", err => done()));
 
-    test("Wrong user", () => {
+    test("Wrong user in GET", () => {
         return makeRequest()
             .get(testURL)
             .query({
@@ -32,7 +46,16 @@ describe("HistoryController API", () => {
             .expect(401, { reason: "Authentication failed" });
     });
 
-    test("Missing fields", () => {
+    test("Wrong user in DELETE", () => {
+        return makeRequest()
+            .delete(testURL)
+            .query({
+                userToken: "Wrongtoken123",
+            })
+            .expect(401, { reason: "Authentication failed" });
+    });
+
+    test("Missing fields in GET", () => {
         return makeRequest()
             .get(testURL)
             .query({ userToken })
@@ -48,38 +71,71 @@ describe("HistoryController API", () => {
             })
     });
 
+    test("Missing fields in DELETE", () => {
+        return makeRequest()
+            .delete(testURL)
+            .expect(400, { reason: "Missing fields" });
+    });
+
     test("Correct user and has entries", () => {
-
-        const testEntry = {
-            userID,
-            timestamp: new Date().toISOString(),
-            operationType: "payment",
-            products: [
-                {
-                    _id: mongoose.Types.ObjectId(1).toHexString(),
-                    quantity: 12,
-                    unitPriceEuros: 4
-                }
-            ]
-        };
-
         return new HistoryEntry(testEntry)
-        .save()
-        .then(() => {
-            return makeRequest()
-                .get(testURL)
-                .query({
-                    userToken,
-                    beforeTimestamp: new Date(),
-                    pageSize: 10
-                })
-        })
-        .then(response => {
-            expect(response.status).toBe(200);
-            expect(response.body.length).toBe(1);
-            expect(response.body[0].timestamp).toBe(testEntry.timestamp);
-            expect(response.body[0].operationType).toBe(testEntry.operationType);
-            expect(response.body[0].products).toMatchObject(testEntry.products);
-        });
+            .save()
+            .then(() => {
+                return makeRequest()
+                    .get(testURL)
+                    .query({
+                        userToken,
+                        beforeTimestamp: new Date(),
+                        pageSize: 10
+                    })
+            })
+            .then(response => {
+                expect(response.status).toBe(200);
+                expect(response.body.length).toBe(1);
+                expect(response.body[0].timestamp).toBe(testEntry.timestamp);
+                expect(response.body[0].operationType).toBe(testEntry.operationType);
+                expect(response.body[0].products).toMatchObject(testEntry.products);
+            });
+    });
+
+    test("Correct DELETE", () => {
+        return new HistoryEntry(testEntry)
+            .save()
+            .then(() => {
+                return makeRequest()
+                    .get(testURL)
+                    .query({
+                        userToken,
+                        beforeTimestamp: new Date(),
+                        pageSize: 1
+                    });
+            })
+            .then(response => {
+                expect(response.status).toBe(200);
+                expect(response.body.length).toBe(1);
+                expect(response.body[0].timestamp).toBe(testEntry.timestamp);
+                expect(response.body[0].operationType).toBe(testEntry.operationType);
+                expect(response.body[0].products).toMatchObject(testEntry.products);
+
+                return makeRequest()
+                    .delete(testURL)
+                    .query({ userToken });
+            })
+            .then(response => {
+                expect(response.status).toBe(204);
+                expect(response.body).toMatchObject({});
+
+                return makeRequest()
+                    .get(testURL)
+                    .query({
+                        userToken,
+                        beforeTimestamp: new Date(),
+                        pageSize: 1
+                    });
+            })
+            .then(response => {
+                expect(response.status).toBe(200);
+                expect(response.body.length).toBe(0);
+            });
     });
 });


### PR DESCRIPTION
Terminado método DELETE para el recurso History. Esto es necesario únicamente cuando se va a borrar una cuenta de usuario, que debe borrar su historial de compras completo.
